### PR TITLE
Change how canvas is generated

### DIFF
--- a/libraries/IiifItems/Util/Canvas.php
+++ b/libraries/IiifItems/Util/Canvas.php
@@ -173,8 +173,14 @@ class IiifItems_Util_Canvas extends IiifItems_IiifUtil {
         // Implemented solution uses
         // list($fileWidth, $fileHeight) = getimagesize(FILES_DIR . DIRECTORY_SEPARATOR . $file->getStoragePath());
         $fileMetadata = json_decode($file->metadata);
-        $fileWidth = $fileMetadata->video->resolution_x;
-        $fileHeight = $fileMetadata->video->resolution_y;
+        if($fileMetadata === NULL || !isset($fileMetadata->video)) {
+            _log("Cannot get image size metadata for file {$file->id}", Zend_Log::WARN);
+            $fileWidth = 0;
+            $fileHeight = 0;
+        } else {
+            $fileWidth = $fileMetadata->video->resolution_x;
+            $fileHeight = $fileMetadata->video->resolution_y;
+        }
         $fileJson = array(
             '@id' => public_full_url(array(
                 'things' => 'files',

--- a/libraries/IiifItems/Util/Canvas.php
+++ b/libraries/IiifItems/Util/Canvas.php
@@ -169,7 +169,12 @@ class IiifItems_Util_Canvas extends IiifItems_IiifUtil {
         catch (Exception $e) {
         }
         // If missing or failed, build from file data
-        list($fileWidth, $fileHeight) = getimagesize(FILES_DIR . DIRECTORY_SEPARATOR . $file->getStoragePath());
+        // Commented code relies on file being in files dir, which is not the case if using a storage adapter
+        // Implemented solution uses
+        // list($fileWidth, $fileHeight) = getimagesize(FILES_DIR . DIRECTORY_SEPARATOR . $file->getStoragePath());
+        $fileMetadata = json_decode($file->metadata);
+        $fileWidth = $fileMetadata->video->resolution_x;
+        $fileHeight = $fileMetadata->video->resolution_y;
         $fileJson = array(
             '@id' => public_full_url(array(
                 'things' => 'files',


### PR DESCRIPTION
The previous way of generating height and width for a IIIF canvas relied on images being stored locally, but ours are stored in S3. The way that this file generated the filename for `getimagesize` assumed local storage, and even if the file path could take the S3 storage adapter into account, the function would have to download the image to get the height and width. Instead, this change uses the image metadata that Omeka already stores to get the height and width.