### PR TITLE
Metadata display

### DIFF
--- a/libraries/IiifItems/IiifUtil.php
+++ b/libraries/IiifItems/IiifUtil.php
@@ -76,7 +76,7 @@ class IiifItems_IiifUtil {
         if (!isset($jsonData['metadata'])) {
             $jsonData['metadata'] = array(
                 array(
-                    'label' => 'Original Item',
+                    'label' => __('Record in Omeka'),
                     'value' => '<a href="' . record_url($record) . '">View Omeka page</a>'
                 )
             );

--- a/libraries/IiifItems/IiifUtil.php
+++ b/libraries/IiifItems/IiifUtil.php
@@ -77,7 +77,7 @@ class IiifItems_IiifUtil {
             $jsonData['metadata'] = array(
                 array(
                     'label' => __('Record in Omeka'),
-                    'value' => '<a href="' . record_url($record) . '">View Omeka page</a>'
+                    'value' => '<a href="' . record_url($record) . '">View page</a>'
                 )
             );
         }

--- a/libraries/IiifItems/IiifUtil.php
+++ b/libraries/IiifItems/IiifUtil.php
@@ -85,7 +85,7 @@ class IiifItems_IiifUtil {
             foreach ($elementSet as $elementName => $elementContent) {
                 $jsonData['metadata'][] = array(
                     'label' => $elementName,
-                    'value' => join('<br/>', $elementContent)
+                    'value' => trim(join('<br/>', $elementContent))
                 );
             }
         }

--- a/libraries/IiifItems/IiifUtil.php
+++ b/libraries/IiifItems/IiifUtil.php
@@ -50,7 +50,7 @@ class IiifItems_IiifUtil {
      * @param array $jsonData
      * @param Record $record
      */
-    protected static function addDublinCoreMetadata(&$jsonData, $record) {
+    protected static function addMetadata(&$jsonData, $record) {
         $elements = all_element_texts($record, array(
             'return_type' => 'array',
             'show_element_set_headings' => true,
@@ -72,16 +72,21 @@ class IiifItems_IiifUtil {
                 $jsonData['license'] = join('<br>', $elements['Dublin Core']['Rights']);
                 unset($elements['Dublin Core']['Rights']);
             }
-            if (!empty($elements['Dublin Core'])) {
-                if (!isset($jsonData['metadata'])) {
-                    $jsonData['metadata'] = array();
-                }
-                foreach ($elements['Dublin Core'] as $elementName => $elementContent) {
-                    $jsonData['metadata'][] = array(
-                        'label' => $elementName,
-                        'value' => join('<br>', $elementContent)
-                    );
-                }
+        }
+        if (!isset($jsonData['metadata'])) {
+            $jsonData['metadata'] = array(
+                array(
+                    'label' => 'Original Item',
+                    'value' => '<a href="' . record_url($record) . '">View Omeka page</a>'
+                )
+            );
+        }
+        foreach ($elements as $elementSetName => $elementSet) {
+            foreach ($elementSet as $elementName => $elementContent) {
+                $jsonData['metadata'][] = array(
+                    'label' => $elementName,
+                    'value' => join('<br/>', $elementContent)
+                );
             }
         }
     }

--- a/libraries/IiifItems/Util/Canvas.php
+++ b/libraries/IiifItems/Util/Canvas.php
@@ -58,8 +58,8 @@ class IiifItems_Util_Canvas extends IiifItems_IiifUtil {
         if (self::_containsNonIiifFile($itemFiles)) {
             $representativeType = self::_getNonIiifType($itemFiles);
             $representativeUrlBase = str_replace(
-                array('{FILENAME}', '{EXTENSION}', '{FULLNAME}'), 
-                array('iiifitems_' . $representativeType, 'jpg', 'iiifitems_' . $representativeType . '.jpg'), 
+                array('{FILENAME}', '{EXTENSION}', '{FULLNAME}'),
+                array('iiifitems_' . $representativeType, 'jpg', 'iiifitems_' . $representativeType . '.jpg'),
                 get_option('iiifitems_bridge_prefix')
             );
             $iiifJsonData['images'][] = array(
@@ -110,7 +110,7 @@ class IiifItems_Util_Canvas extends IiifItems_IiifUtil {
         }
         // Plug DC metadata
         if ($applyDublin) {
-            parent::addDublinCoreMetadata($iiifJsonData, $item);
+            parent::addMetadata($iiifJsonData, $item);
         }
         // Plug otherContent for annotation lists
         if (is_admin_theme()) {
@@ -128,7 +128,7 @@ class IiifItems_Util_Canvas extends IiifItems_IiifUtil {
         // Done
         return $iiifJsonData;
     }
-    
+
     /**
      * Return the IIIF Presentation API canvas representation of a single annotation on its attached item
      * @param Item $annotation Annotation-typed item
@@ -148,7 +148,7 @@ class IiifItems_Util_Canvas extends IiifItems_IiifUtil {
         ));
         return $base;
     }
-    
+
     /**
      * Return the IIIF Presentation API image representation of a file
      * @param File $file
@@ -205,7 +205,7 @@ class IiifItems_Util_Canvas extends IiifItems_IiifUtil {
         );
         return $fileJson;
     }
-    
+
     /**
      * Return the IIIF prefix for the given local File record.
      * @param File $file
@@ -214,8 +214,8 @@ class IiifItems_Util_Canvas extends IiifItems_IiifUtil {
     public static function fileIiifPrefix($file) {
         $bridgePrefix = get_option('iiifitems_bridge_prefix');
         $replacedBridgePrefix = str_replace(
-            array('{FILENAME}', '{EXTENSION}', '{FULLNAME}'), 
-            array(basename($file->filename), $file->DERIVATIVE_EXT, $file->filename), 
+            array('{FILENAME}', '{EXTENSION}', '{FULLNAME}'),
+            array(basename($file->filename), $file->DERIVATIVE_EXT, $file->filename),
             $bridgePrefix
         );
         return $replacedBridgePrefix;
@@ -244,11 +244,11 @@ class IiifItems_Util_Canvas extends IiifItems_IiifUtil {
         $json = self::blankTemplate($canvasId, $fileImageJson['resource']['width'], $fileImageJson['resource']['height'], $displayTitle, array($fileImageJson));
         // Apply Dublin Core metadata
         if ($applyDublin) {
-            parent::addDublinCoreMetadata($json, $file);
+            parent::addMetadata($json, $file);
         }
         return $json;
     }
-    
+
     /**
      * Return whether this item is not presentable in IIIF
      * @param Item $item
@@ -257,7 +257,7 @@ class IiifItems_Util_Canvas extends IiifItems_IiifUtil {
     public static function isNonIiifItem($item) {
         return ($item->item_type_id != get_option('iiifitems_annotation_item_type') && self::_containsNonIiifFile($item->getFiles())) || raw_iiif_metadata($item, 'iiifitems_item_display_element') == 'Never';
     }
-    
+
     /**
      * Return whether the array contains non-IIIF File records
      * @param array $files
@@ -275,7 +275,7 @@ class IiifItems_Util_Canvas extends IiifItems_IiifUtil {
         }
         return false;
     }
-    
+
     /**
      * Return the multimedia type of the files given.
      * @param array $files

--- a/libraries/IiifItems/Util/Canvas.php
+++ b/libraries/IiifItems/Util/Canvas.php
@@ -29,11 +29,11 @@ class IiifItems_Util_Canvas extends IiifItems_IiifUtil {
      * Return the IIIF Presentation API canvas representation of an ordinary item
      * @param Item $item Non-annotation-typed item
      * @param string $canvasId (optional) Replacement canvas URI
-     * @param boolean $applyDublin (optional) Whether to apply Dublin Core metadata
+     * @param boolean $applyMetadata (optional) Whether to apply all associated metadata
      * @param array $images (optional) An array of IIIF Presentation API images
      * @return array
      */
-    public static function buildCanvas($item, $canvasId=null, $applyDublin=true) {
+    public static function buildCanvas($item, $canvasId=null, $applyMetadata=true) {
         // Fetch the canvas for the given item from IIIF metadata
         try {
             $iiifJsonData = parent::fetchJsonData($item);
@@ -109,7 +109,7 @@ class IiifItems_Util_Canvas extends IiifItems_IiifUtil {
             }
         }
         // Plug DC metadata
-        if ($applyDublin) {
+        if ($applyMetadata) {
             parent::addMetadata($iiifJsonData, $item);
         }
         // Plug otherContent for annotation lists
@@ -133,10 +133,10 @@ class IiifItems_Util_Canvas extends IiifItems_IiifUtil {
      * Return the IIIF Presentation API canvas representation of a single annotation on its attached item
      * @param Item $annotation Annotation-typed item
      * @param string $canvasId (optional) Replacement canvas URI
-     * @param boolean $applyDublin (optional) Whether to apply Dublin Core metadata
+     * @param boolean $applyMetadata (optional) Whether to apply all associated metadata
      * @return array
      */
-    public static function buildAnnotationCanvas($annotation, $canvasId=null, $applyDublin=true) {
+    public static function buildAnnotationCanvas($annotation, $canvasId=null, $applyMetadata=true) {
         $base = self::buildCanvas(IiifItems_Util_Annotation::findAnnotatedItemFor($annotation));
         $base['otherContent'] = array(array(
             '@id' => public_full_url(array(
@@ -225,10 +225,10 @@ class IiifItems_Util_Canvas extends IiifItems_IiifUtil {
      * Return a quick-display IIIF Presentation API canvas representation of a file
      * @param File $file
      * @param string $canvasId (optional) Replacement canvas URI
-     * @param boolean $applyDublin (optional) Whether to apply Dublin Core metadata
+     * @param boolean $applyMetadata (optional) Whether to apply all associated metadata
      * @return array
      */
-    public static function fileCanvasJson($file, $canvasId=null, $applyDublin=false) {
+    public static function fileCanvasJson($file, $canvasId=null, $applyMetadata=false) {
         // Default IDs and display titles
         if (!$canvasId) {
             $canvasId = public_full_url(array(
@@ -242,8 +242,8 @@ class IiifItems_Util_Canvas extends IiifItems_IiifUtil {
         $fileImageJson = self::fileImageJson($file, $canvasId, true);
         // Create IIIF Presentation 2.0 top-level template
         $json = self::blankTemplate($canvasId, $fileImageJson['resource']['width'], $fileImageJson['resource']['height'], $displayTitle, array($fileImageJson));
-        // Apply Dublin Core metadata
-        if ($applyDublin) {
+        // Apply all associated metadata
+        if ($applyMetadata) {
             parent::addMetadata($json, $file);
         }
         return $json;

--- a/libraries/IiifItems/Util/Manifest.php
+++ b/libraries/IiifItems/Util/Manifest.php
@@ -71,7 +71,7 @@ class IiifItems_Util_Manifest extends IiifItems_IiifUtil {
             $json['@id'] = $atId;
             $json['sequences'][0]['@id'] = $seqId;
             $json['sequences'][0]['canvases'] = self::findCanvasesFor($collection);
-            parent::addDublinCoreMetadata($json, $collection);
+            parent::addMetadata($json, $collection);
             // Cache accordingly
             cache_iiifitems_value_for($collection, $json, $cacheEntryName);
             // Done
@@ -103,7 +103,7 @@ class IiifItems_Util_Manifest extends IiifItems_IiifUtil {
             ));
         }
         // Override DC metadata
-        parent::addDublinCoreMetadata($json, $item);
+        parent::addMetadata($json, $item);
         if ($item->collection_id !== null) {
             $json['label'] = metadata(get_record_by_id('Collection', $item->collection_id), array('Dublin Core', 'Title'), array('no_escape' => true));
         }
@@ -126,7 +126,7 @@ class IiifItems_Util_Manifest extends IiifItems_IiifUtil {
             IiifItems_Util_Canvas::fileCanvasJson($file)
         ));
         // Override DC metadata
-        parent::addDublinCoreMetadata($json, $file);
+        parent::addMetadata($json, $file);
         // Done
         return $json;
     }


### PR DESCRIPTION
This PR addresses some issues that came up in discussion with Jinah Kim's Mapping Color team. The current metadata display is limited to just the Dublin Core metadata, and so it ignores any other metadata, including item type or other metadata added by plugins. This removes that restriction on what metadata is included in manifests, and adds a metadata element to link back to the page in Omeka.